### PR TITLE
adds a configuration for the port

### DIFF
--- a/lita_config.rb
+++ b/lita_config.rb
@@ -26,6 +26,8 @@ Lita.configure do |config|
   # config.adapters.slack.unfurl_links = false
   # config.adapters.slack.unfurl_media = false
 
+  config.http.port = ENV.fetch('PORT', 8080)
+
   ## Example: Set options for the chosen adapter.
   # config.adapter.username = "myname"
   # config.adapter.password = "secret"


### PR DESCRIPTION
Heroku need to set the port via the env variable  to ensure there is no port conflict between applications