### PR TITLE
chore(): add support for messages with buttons

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,8 +10,9 @@ gem "lita-lightning", github: "platanus/lita-lightning-bot"
 gem "lita-lunch-reminder", github: "platanus/lita-lunch-reminder", require: false
 gem "lita-office-automation", github: "platanus/lita-office-automation"
 gem "lita-pull-requests", github: "platanus/lita-pull-requests"
-gem "lita_time_tracker", github: "platanus/lita_time_tracker"
+gem "lita-slack-actions", github: "platanus/lita-slack-actions"
 gem "lita-trainer-bot", github: "platanus/lita-trainer-bot"
+gem "lita_time_tracker", github: "platanus/lita_time_tracker"
 gem 'slack-ruby-client'
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,6 +63,13 @@ GIT
       rufus-scheduler (= 2.0.24)
 
 GIT
+  remote: git://github.com/platanus/lita-slack-actions.git
+  revision: 8f5ace2d3e29c25105731e83913fccfed6c30088
+  specs:
+    lita-slack-actions (0.1.0)
+      lita (>= 4.7)
+
+GIT
   remote: git://github.com/platanus/lita-trainer-bot.git
   revision: 946372ca7293a5f87c4917a207cd97f172b347ac
   specs:
@@ -248,10 +255,11 @@ DEPENDENCIES
   lita-office-automation!
   lita-pull-requests!
   lita-slack
+  lita-slack-actions!
   lita-trainer-bot!
   lita_time_tracker!
   pry
   slack-ruby-client
 
 BUNDLED WITH
-   1.17.3
+   2.0.1


### PR DESCRIPTION
Se reemplaza `lita-slack` por un fork con la capacidad de procesar los attachments con botones. De paso se agrega plugin para procesar los botones.